### PR TITLE
fix comparison between signed and unsigned integer

### DIFF
--- a/PCA9685.cpp
+++ b/PCA9685.cpp
@@ -830,7 +830,7 @@ uint16_t PCA9685_ServoEvaluator::pwmForAngle(float angle) {
         }
     }
     
-    return (uint16_t)constrain((int)roundf(retVal), 0, PCA9685_PWM_FULL);
+    return (uint16_t)constrain((uint16_t)roundf(retVal), 0, PCA9685_PWM_FULL);
 };
 
 #endif


### PR DESCRIPTION
I suggest cast _retVal_ to unsigned or _PCA9685_PWM_FULL_ to signed to overcome comparison between signed and unsigned integer values.

Detailed compiler error:
```
Compiling .pio/build/leonardo/lib021/PCA9685 16-Channel PWM Driver Module Library_ID2100/PCA9685.cpp.o
In file included from .pio/libdeps/leonardo/PCA9685 16-Channel PWM Driver Module Library_ID2100/PCA9685.h:56:0,
                 from .pio/libdeps/leonardo/PCA9685 16-Channel PWM Driver Module Library_ID2100/PCA9685.cpp:25:
.pio/libdeps/leonardo/PCA9685 16-Channel PWM Driver Module Library_ID2100/PCA9685.cpp: In member function 'uint16_t PCA9685_ServoEvaluator::pwmForAngle(float)':
~/.platformio/packages/framework-arduino-avr/cores/arduino/Arduino.h:95:58: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
                                                          ^
.pio/libdeps/leonardo/PCA9685 16-Channel PWM Driver Module Library_ID2100/PCA9685.cpp:833:22: note: in expansion of macro 'constrain'
     return (uint16_t)constrain((int)roundf(retVal), 0, PCA9685_PWM_FULL);
```